### PR TITLE
Update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "camelcase": "^1.0.2",
     "kat": "^0.3.0",
-    "lodash": "^3.3.1",
+    "lodash": "^4.17.5",
     "minimist": "^1.1.0",
     "postcss": "^4.0.6",
     "stringify-object": "^1.0.0",


### PR DESCRIPTION
Current version of lodash has [a vulnerability](https://www.npmjs.com/advisories/577), updating to `4.17.5` addresses the issue.  [`lodash-migrate`](https://www.npmjs.com/package/lodash-migrate) noted no problems upgrading the dependency.  